### PR TITLE
Better nullifyMatrix implementation.

### DIFF
--- a/Ch 1.Arrays And Strings/8.Zero_matrix/8.zero_matrix.cpp
+++ b/Ch 1.Arrays And Strings/8.Zero_matrix/8.zero_matrix.cpp
@@ -26,7 +26,6 @@ void nullifyCol( int ** matrix, int M, int col ) {
 
 void nullifyMatrix( int ** matrix, int M, int N ) {
 	bool firstRow = false;
-	bool firstCol = false;
 
 	//first row
 	for( int i = 0; i < N; ++i ) {
@@ -36,34 +35,22 @@ void nullifyMatrix( int ** matrix, int M, int N ) {
 		}
 	}
 
-	//first col
-	for ( int i = 0; i < M; ++i ) {
-		if ( matrix[i][0] == 0 ) {
-			firstCol = true;
-			break;
-		}
-	}
-
 	//rest of the matrix
 	for( int i = 1; i < M; ++i ) {
-		for ( int j = 1; j < N; ++j ) {
+		bool nullifyThisRow = false;
+		for ( int j = 0; j < N; ++j ) {
 			if ( matrix[i][j] == 0 ) {
-				matrix[i][0] = 0;
 				matrix[0][j] = 0;
+				nullifyThisRow = true;
 			}
 		}
-	}
-
-	//now we know which row and column to be nullify using information stored in previous step.
-	//rows first
-	for ( int i = 1; i < M; ++i )  {
-		if ( matrix[i][0]  == 0 ) {
+		if (nullifyThisRow)
 			nullifyRow(matrix, N, i);
-		}
 	}
 
-	//cols now
-	for ( int j = 1; j < N; ++j ) {
+	//now we know which column to be nullify using information stored in previous step.
+	//cols first
+	for ( int j = 0; j < N; ++j ) {
 		if ( matrix[0][j] == 0 ) {
 			nullifyCol(matrix, M,  j);
 		}
@@ -72,11 +59,6 @@ void nullifyMatrix( int ** matrix, int M, int N ) {
 	//now first row
 	if ( firstRow ) {
 		nullifyRow(matrix, N, 0);
-	}
-
-	//now first col
-	if ( firstCol ) {
-		nullifyCol(matrix, M, 0);
 	}
 
 }


### PR DESCRIPTION
We do not need to store information into the first column which rows to nullify. We can nullify currently iterated row after its cells are compared with zero.
As a result my changes make the code shorter and faster, since one walk through the first column is removed (yet another possible advantage: column cells probably are not in CPU cache at a time, since they can be allocated in different and far memory pages).